### PR TITLE
Separate spotify preferences from muse preferences

### DIFF
--- a/api/controller/spotify_controller.js
+++ b/api/controller/spotify_controller.js
@@ -244,22 +244,6 @@ module.exports = {
     return res.json(response);
   },
 
-  isNewUser: async (req, res) => {
-    const spotify_user_data = await USER_MANAGER.fetchUserData(req.query.access_token);
-    if (spotify_user_data.error != null) return res.json(spotify_user_data);
-
-    const response = await USER_MANAGER.isNewUser(spotify_user_data.email);
-    return res.json(response);
-  },
-
-  syncedNewUser: async (req, res) => {
-    const spotify_user_data = await USER_MANAGER.fetchUserData(req.body.access_token);
-    if (spotify_user_data.error != null) return res.json(spotify_user_data);
-
-    const response = await USER_MANAGER.syncedNewUser(spotify_user_data.email);
-    return res.json(response);
-  },
-
   updateUserSeeds: async (req, res) => {
     let { access_token, artist_ids, type } = req.body;
     if (type !== "muse" && type !== "spotify") {

--- a/api/controller/spotify_controller.js
+++ b/api/controller/spotify_controller.js
@@ -122,10 +122,32 @@ selectWeightedRandoms = (data_struct, max_size) => {
   return selectedRandoms;
 }
 
+mergeSeedObjs = (obj1, obj2) => {
+  let merged = {};
+
+  for (var key in obj1) {
+    if (obj2[key] == null) { // keys in obj1 not in obj2
+      merged[key] = obj1[key];
+    } else { // keys in obj1 and obj2
+      let merged_weight = obj1[key].weight + obj2[key].weight;
+      let merged_value = { weight: merged_weight, last_accessed: 0 };
+      merged[key] = merged_value;
+    }
+  }
+
+  for (var key in obj2) { // keys in obj2 not in obj1
+    if (obj1[key] == null) {
+      merged[key] = obj2[key];
+    }
+  }
+
+  return merged;
+}
+
 module.exports = {
   userSeedRecommendedSongSelection: async (req, res) => {
     const { access_token, limit: max_result_tracks } = req.body;
-    const max_seed_list_size = 5;
+    const max_seed_list_size = 5; // the max number of seeds that Spotify API will take
 
     const spotify_user_data = await USER_MANAGER.fetchUserData(req.body.access_token);
     if (spotify_user_data.error != null) return res.json(spotify_user_data);
@@ -133,8 +155,11 @@ module.exports = {
     const seeds = await USER_MANAGER.fetchUserSeeds(spotify_user_data.email);
     if (seeds.error != null) return res.json(seeds);
 
-    let artist_seeds = selectWeightedRandoms(seeds.fav_artists, max_seed_list_size);
-    let genre_seeds = selectWeightedRandoms(seeds.fav_genres, max_seed_list_size);
+    let merged_fav_artists = mergeSeedObjs(seeds.fav_artists, seeds.spotify_fav_artists);
+    let merged_fav_genres = mergeSeedObjs(seeds.fav_genres, seeds.spotify_fav_genres);
+
+    let artist_seeds = selectWeightedRandoms(merged_fav_artists, max_seed_list_size);
+    let genre_seeds = selectWeightedRandoms(merged_fav_genres, max_seed_list_size);
 
     // Combined the seeds, shuffle and pick 5
     let combined_seeds = getRandomSublist(artist_seeds.concat(genre_seeds), 5);
@@ -211,6 +236,14 @@ module.exports = {
     return res.json(response);
   },
 
+  lastSyncedWithSpotify: async (req, res) => {
+    const spotify_user_data = await USER_MANAGER.fetchUserData(req.query.access_token);
+    if (spotify_user_data.error != null) return res.json(spotify_user_data);
+
+    const response = await USER_MANAGER.lastSyncedWithSpotify(spotify_user_data.email);
+    return res.json(response);
+  },
+
   isNewUser: async (req, res) => {
     const spotify_user_data = await USER_MANAGER.fetchUserData(req.query.access_token);
     if (spotify_user_data.error != null) return res.json(spotify_user_data);
@@ -228,9 +261,13 @@ module.exports = {
   },
 
   updateUserSeeds: async (req, res) => {
-    let { access_token, artist_ids } = req.body;
+    let { access_token, artist_ids, type } = req.body;
+    if (type !== "muse" && type !== "spotify") {
+      res.json({error: 'Invalid type provided'});
+    }
+
     artist_ids = splitList(artist_ids, 50);
-    const response = await USER_MANAGER.updateUserSeeds(access_token, artist_ids);
+    const response = await USER_MANAGER.updateUserSeeds(access_token, artist_ids, type);
     res.json(response);
   },
 

--- a/api/controller/spotify_controller.js
+++ b/api/controller/spotify_controller.js
@@ -135,13 +135,7 @@ mergeSeedObjs = (obj1, obj2) => {
     }
   }
 
-  for (var key in obj2) { // keys in obj2 not in obj1
-    if (obj1[key] == null) {
-      merged[key] = obj2[key];
-    }
-  }
-
-  return merged;
+  return {...obj2, ...merged}; // keys in obj2 and not obj1
 }
 
 module.exports = {
@@ -150,10 +144,10 @@ module.exports = {
     const max_seed_list_size = 5; // the max number of seeds that Spotify API will take
 
     const spotify_user_data = await USER_MANAGER.fetchUserData(req.body.access_token);
-    if (spotify_user_data.error != null) return res.json(spotify_user_data);
+    if (spotify_user_data.error) return res.json(spotify_user_data);
 
     const seeds = await USER_MANAGER.fetchUserSeeds(spotify_user_data.email);
-    if (seeds.error != null) return res.json(seeds);
+    if (seeds.error) return res.json(seeds);
 
     let merged_fav_artists = mergeSeedObjs(seeds.fav_artists, seeds.spotify_fav_artists);
     let merged_fav_genres = mergeSeedObjs(seeds.fav_genres, seeds.spotify_fav_genres);
@@ -230,7 +224,7 @@ module.exports = {
 
   verifyEnoughData: async (req, res) => {
     const spotify_user_data = await USER_MANAGER.fetchUserData(req.query.access_token);
-    if (spotify_user_data.error != null) return res.json(spotify_user_data);
+    if (spotify_user_data.error) return res.json(spotify_user_data);
 
     const response = await USER_MANAGER.verifyUserSeeds(spotify_user_data.email);
     return res.json(response);
@@ -238,7 +232,7 @@ module.exports = {
 
   lastSyncedWithSpotify: async (req, res) => {
     const spotify_user_data = await USER_MANAGER.fetchUserData(req.query.access_token);
-    if (spotify_user_data.error != null) return res.json(spotify_user_data);
+    if (spotify_user_data.error) return res.json(spotify_user_data);
 
     const response = await USER_MANAGER.lastSyncedWithSpotify(spotify_user_data.email);
     return res.json(response);

--- a/api/managers/auth_manager.js
+++ b/api/managers/auth_manager.js
@@ -44,6 +44,11 @@ module.exports = {
         data: {
           country: spotify_user_data.country,
           is_new_user: true,
+          last_synced_with_spotify: 0, // so that first personalized session will always pass timestamp check to sync
+          spotify_fav_artists: {},
+          spotify_fav_genres: {},
+          fav_artists: {},
+          fav_genres: {},
         },
       };
       await datastore.save(new_user_entity);

--- a/api/managers/auth_manager.js
+++ b/api/managers/auth_manager.js
@@ -30,7 +30,7 @@ module.exports = {
 
   registerUser: async (access_token) => {
     const spotify_user_data = await USER_MANAGER.fetchUserData(access_token);
-    if (spotify_user_data.error != null) throw spotify_user_data.error;
+    if (spotify_user_data.error) throw spotify_user_data.error;
 
     const kind = 'User';
     const user_key = datastore.key([kind, spotify_user_data.email]);

--- a/api/managers/user_manager.js
+++ b/api/managers/user_manager.js
@@ -50,7 +50,7 @@ insertWithLruPolicy = (data_struct, key) => {
   let current_time = Date.now();
 
   // If key exists already, inc weight and update accessed time to current time
-  if (data_struct[key] != null) {
+  if (data_struct[key]) {
     data_struct[key].weight += 1;
     data_struct[key].last_accessed = current_time;
     return data_struct;
@@ -178,7 +178,7 @@ module.exports = {
   //   On failure: JSON containing error key
   fetchUserSeeds: async (user_email) => {
     const muse_user_data = await module.exports.fetchUserDatastoreData(user_email);
-    if (muse_user_data.error != null) return muse_user_data;
+    if (muse_user_data.error) return muse_user_data;
 
     return {
       fav_artists: muse_user_data.data.fav_artists,
@@ -194,13 +194,13 @@ module.exports = {
   //   On failure: JSON containing error key
   verifyUserSeeds: async (user_email) => {
     const user_seeds = await module.exports.fetchUserSeeds(user_email);
-    if (user_seeds.error != null) return user_seeds;
+    if (user_seeds.error) return user_seeds;
 
     // verify user has enough artists and genres for seeding
-    if (user_seeds.fav_artists != null && Object.keys(user_seeds.fav_artists).length >= 1) return { has_enough_data: true };
-    if (user_seeds.fav_genres != null && Object.keys(user_seeds.fav_genres).length >= 1) return { has_enough_data: true };
-    if (user_seeds.spotify_fav_artists != null && Object.keys(user_seeds.spotify_fav_artists).length >= 1) return { has_enough_data: true };
-    if (user_seeds.spotify_fav_genres != null && Object.keys(user_seeds.spotify_fav_genres).length >= 1) return { has_enough_data: true };
+    if (user_seeds.fav_artists && Object.keys(user_seeds.fav_artists).length >= 1) return { has_enough_data: true };
+    if (user_seeds.fav_genres && Object.keys(user_seeds.fav_genres).length >= 1) return { has_enough_data: true };
+    if (user_seeds.spotify_fav_artists && Object.keys(user_seeds.spotify_fav_artists).length >= 1) return { has_enough_data: true };
+    if (user_seeds.spotify_fav_genres && Object.keys(user_seeds.spotify_fav_genres).length >= 1) return { has_enough_data: true };
 
     // Does not have at least 1 genre or artist preference saved
     return { has_enough_data: false };
@@ -212,7 +212,7 @@ module.exports = {
   //   On failure: JSON containing error key
   lastSyncedWithSpotify: async (user_email) => {
     const user_data = await module.exports.fetchUserDatastoreData(user_email);
-    if (user_data.error != null) return user_data;
+    if (user_data.error) return user_data;
 
     return { last_synced_with_spotify: user_data.data.last_synced_with_spotify };
   },
@@ -223,7 +223,7 @@ module.exports = {
   //   On failure: JSON containing the key "error"
   updateUserSeeds: async (access_token, artist_ids, type) => {
     const spotify_user_data = await module.exports.fetchUserData(access_token);
-    if (spotify_user_data.error != null) return spotify_user_data;
+    if (spotify_user_data.error) return spotify_user_data;
 
     const kind = 'User';
     const user_key = datastore.key([kind, spotify_user_data.email]);
@@ -243,7 +243,7 @@ module.exports = {
     }
 
     prefs = await updateArtistAndGenrePreferences(access_token, artist_ids, updated_fav_artists, updated_fav_genres);
-    if (prefs.error != null) return prefs;
+    if (prefs.error) return prefs;
 
     var updated_user_entity = {
       key: user_key,

--- a/api/managers/user_manager.js
+++ b/api/managers/user_manager.js
@@ -217,47 +217,6 @@ module.exports = {
     return { last_synced_with_spotify: user_data.data.last_synced_with_spotify };
   },
 
-  // Check if user is a new user
-  // Returns:
-  //   On success: JSON containing is_new_user key with the value of true or false
-  //   On failure: JSON containing error key
-  isNewUser: async (user_email) => {
-    const user_data = await module.exports.fetchUserDatastoreData(user_email);
-    if (user_data.error != null) return user_data;
-
-    return { is_new_user: user_data.data.is_new_user };
-  },
-
-  // Update a user as a non new user
-  // Returns:
-  //   On success: JSON containing the key "updated"
-  //   On failure: JSON containing the key "error"
-  syncedNewUser: async (user_email) => {
-    const kind = 'User';
-    const user_key = datastore.key([kind, user_email]);
-    const muse_user_data = await module.exports.fetchUserDatastoreData(user_email);
-
-    var updated_user_entity = {
-      key: user_key,
-      data: {
-        fav_artists: muse_user_data.data.fav_artists,
-        fav_genres: muse_user_data.data.fav_genres,
-        spotify_fav_artists: muse_user_data.spotify_fav_artists,
-        spotify_fav_genres: muse_user_data.spotify_fav_genres,
-        country: muse_user_data.data.country,
-        is_new_user: false,
-        last_synced_with_spotify: muse_user_data.data.last_synced_with_spotify,
-      },
-    };
-
-    try {
-      await datastore.save(updated_user_entity);
-      return { updated: true };
-    } catch (error) {
-      return { error: error };
-    }
-  },
-
   // Create or update the muse or spotify artist and genre seeds for the current user
   // Returns:
   //   On success: JSON containing the key "updated"

--- a/server.js
+++ b/server.js
@@ -34,6 +34,8 @@ app.post('/api/sync_user_preferences', spotify_controller.updateUserSeeds);
 
 app.post('/api/get_songs_from_user_pref', spotify_controller.userSeedRecommendedSongSelection);
 
+app.get('/api/last_synced_with_spotify', spotify_controller.lastSyncedWithSpotify);
+
 app.get('/api/is_new_user', spotify_controller.isNewUser);
 
 app.post('/api/synced_new_user', spotify_controller.syncedNewUser);

--- a/server.js
+++ b/server.js
@@ -36,8 +36,4 @@ app.post('/api/get_songs_from_user_pref', spotify_controller.userSeedRecommended
 
 app.get('/api/last_synced_with_spotify', spotify_controller.lastSyncedWithSpotify);
 
-app.get('/api/is_new_user', spotify_controller.isNewUser);
-
-app.post('/api/synced_new_user', spotify_controller.syncedNewUser);
-
 app.listen(port, () => console.log(`Listening on port ${port}`));


### PR DESCRIPTION
Separate Spotify preferences from Muse preferences. This allows us to sync Spotify preferences that can often change periodically from the frontend when users attempt to start a personalized session.

On sync, we will discard the previous struct that holds the spotify data and replace it with the result of the new sync.

On fetch for personalized songs, we will merge the spotify data struct with muse data struct.

TODO: Make a PR in the client side code to respect these changes. Make sure we are making use of the enough data for the personalized flow. Currently on the client side I think I missed the case of redirecting users to the category flow if they don't have any data for personalization flow.

Other non-urgent TODOs:
  - Come up with a weight normalization algorithm